### PR TITLE
Add Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+python: 2.7
 env:
   - TOXENV=py26
   - TOXENV=py27

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python: 2.7
+env:
+  - TOXENV=py26
+  - TOXENV=py27
+  - TOXENV=flake8
+install: pip install tox
+script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-python: 2.7
 env:
   - TOXENV=py26
   - TOXENV=py27

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
+[![Build Status](https://travis-ci.org/abusesa/idiokit.svg)](https://travis-ci.org/abusesa/idiokit)
+
 idiokit is current (c) by Codenomicon Ltd. and licensed under the MIT license (http://www.opensource.org/licenses/MIT - see the LICENSE file).


### PR DESCRIPTION
Use ```tox``` to run ```py.test``` for both Python 2.6 and Python 2.7. Also run the code through ```flake8```.