### PR TITLE
Add Requests-style Client#mount to idiokit.http.client

### DIFF
--- a/idiokit/http/tests/test_client.py
+++ b/idiokit/http/tests/test_client.py
@@ -1,0 +1,66 @@
+import os
+import shutil
+import urllib
+import idiokit
+import unittest
+import tempfile
+from idiokit import socket
+
+from ..client import Client, HTTPUnixAdapter
+
+
+@idiokit.stream
+def serve(test_string, sock):
+    conn, _ = yield sock.accept()
+    try:
+        request = ""
+        while True:
+            data = yield conn.recv(1024)
+            if not data:
+                raise RuntimeError("not enough data")
+
+            request += data
+            if "\r\n\r\n" in request:
+                break
+
+        yield conn.sendall("HTTP/1.0 200 OK\r\n")
+        yield conn.sendall("\r\n")
+        yield conn.sendall(test_string)
+    finally:
+        yield conn.close()
+
+
+class TestClient(unittest.TestCase):
+    def test_http_unix_adapter(self):
+        @idiokit.stream
+        def main(test_string):
+            s = socket.Socket(socket.AF_UNIX)
+            try:
+                tmpdir = tempfile.mkdtemp()
+                try:
+                    path = os.path.join(tmpdir, "socket")
+                    yield s.bind(path)
+                    yield s.listen(1)
+                    result = yield serve(test_string, s) | connect(path)
+                finally:
+                    shutil.rmtree(tmpdir)
+            finally:
+                yield s.close()
+            idiokit.stop(result)
+
+        @idiokit.stream
+        def connect(path):
+            client = Client()
+            client.mount("http+unix://", HTTPUnixAdapter())
+            request = yield client.request("GET", "http+unix://" + urllib.quote(path, ""))
+            response = yield request.finish()
+
+            result = ""
+            while True:
+                data = yield response.read(1024)
+                if not data:
+                    break
+                result += data
+            idiokit.stop(result)
+
+        self.assertEqual("this is a test", idiokit.main_loop(main("this is a test")))


### PR DESCRIPTION
This pull request adds providing custom adapters for e.g. handling custom URL schemes. The API mimics the [corresponding functionality](http://docs.python-requests.org/en/latest/api/#requests.Session.mount) in the Requests library. You can call the method ```mount(prefix, adapter)``` to signal that you want to open URLs starting with ```prefix``` using ```adapter```.

Example:

```
from idiokit.http.client import Client, HTTPUnixAdapter

c = Client()
c.mount("http+unix://", HTTPUnixAdapter())
```

After this the client instance ```c``` can open URLs starting with ```http+unix://``` from local unix domain sockets.