### PR TITLE
Fix DNS name packing

### DIFF
--- a/idiokit/dns/_dns.py
+++ b/idiokit/dns/_dns.py
@@ -560,6 +560,8 @@ def pack_name(name):
         length = len(piece)
         if length == 0:
             raise ValueError("zero length label")
+        elif length > 63:
+            raise ValueError("too long label ({0} bytes)".format(length))
         result.append(chr(len(piece)))
         result.append(piece)
     result.append("\x00")

--- a/idiokit/dns/_dns.py
+++ b/idiokit/dns/_dns.py
@@ -557,6 +557,9 @@ RR.register_type(MX)
 def pack_name(name):
     result = []
     for piece in name.split("."):
+        length = len(piece)
+        if length == 0:
+            raise ValueError("zero length label")
         result.append(chr(len(piece)))
         result.append(piece)
     result.append("\x00")

--- a/idiokit/dns/_dns.py
+++ b/idiokit/dns/_dns.py
@@ -562,9 +562,14 @@ def pack_name(name):
             raise ValueError("zero length label")
         elif length > 63:
             raise ValueError("too long label ({0} bytes)".format(length))
-        result.append(chr(len(piece)))
+
+        result.append(chr(length))
         result.append(piece)
+
     result.append("\x00")
+    if sum(len(x) for x in result) > 255:
+        raise ValueError("too long name")
+
     return "".join(result)
 
 

--- a/idiokit/dns/_dns.py
+++ b/idiokit/dns/_dns.py
@@ -555,6 +555,18 @@ RR.register_type(MX)
 
 
 def pack_name(name):
+    r"""
+    Return a domain name packed into the length-prefixed, zero byte terminated
+    format specified in [RFC 1035][] section 3.1.
+
+    >>> pack_name("a.bc")
+    '\x01a\x02bc\x00'
+
+    Limit the size of each label to 1-63 bytes, as shorter and longer labels can
+    not be expressed in this format. Also limit the total size of the packed name
+    to 255 bytes. Raise a ValueError for values violating these limits.
+    """
+
     result = []
     for piece in name.split("."):
         length = len(piece)

--- a/idiokit/dns/tests/test_dns.py
+++ b/idiokit/dns/tests/test_dns.py
@@ -7,6 +7,9 @@ class PackNameTests(unittest.TestCase):
     def test_pack_valid(self):
         self.assertEqual(_dns.pack_name("a.b.c"), "\x01a\x01b\x01c\x00")
 
+        # Allow names that pack into <= 255 octets.
+        self.assertEqual(_dns.pack_name("a" + (".b" * 126)), "\x01a" + ("\x01b" * 126) + "\x00")
+
     def test_zero_length_label(self):
         self.assertRaises(ValueError, _dns.pack_name, "a..")
         self.assertRaises(ValueError, _dns.pack_name, "a..b")

--- a/idiokit/dns/tests/test_dns.py
+++ b/idiokit/dns/tests/test_dns.py
@@ -3,6 +3,22 @@ import unittest
 from .. import _dns
 
 
+class PackNameTests(unittest.TestCase):
+    def test_pack_valid(self):
+        self.assertEqual(_dns.pack_name("a.b.c"), "\x01a\x01b\x01c\x00")
+
+    def test_zero_length_label(self):
+        self.assertRaises(ValueError, _dns.pack_name, "a..")
+        self.assertRaises(ValueError, _dns.pack_name, "a..b")
+
+    def test_too_long_label(self):
+        self.assertRaises(ValueError, _dns.pack_name, "a." + ("b" * 64))
+
+    def test_too_long_name(self):
+        name = "aa" + (".a" * 126)  # Packs into 256 octets
+        self.assertRaises(ValueError, _dns.pack_name, name)
+
+
 class UnpackNameTests(unittest.TestCase):
     def test_unpack_valid(self):
         self.assertEqual(_dns.unpack_name("\x00"), ("", 1))
@@ -69,7 +85,7 @@ class UnpackNameTests(unittest.TestCase):
         self.assertRaises(_dns.NotEnoughData, _dns.unpack_name, "\x02aa")
         self.assertRaises(_dns.NotEnoughData, _dns.unpack_name, "\x02aa\x00", offset=4)
 
-    def test_truncated_overlong_name(self):
+    def test_too_long_and_truncated_name(self):
         # Check octet count before checking data bounds.
 
         overlong = ("\x3f" + "a" * 63) * 3 + "\x3f"


### PR DESCRIPTION
Add extra tests and checks for ```idiokit.dns._dns.pack_name```, namely handling of too long and too short labels and names.