### PR TITLE
Add User-Agent header to HTTP Client

### DIFF
--- a/idiokit/__init__.py
+++ b/idiokit/__init__.py
@@ -1,4 +1,5 @@
 from .idiokit import (
+    __version__,
     stream,
     next,
     send,
@@ -16,9 +17,8 @@ from .timer import sleep
 from .threadpool import thread
 
 
-__version__ = "2.2.0"
-
 __all__ = [
+    "__version__",
     "stream",
     "next",
     "send",

--- a/idiokit/__init__.py
+++ b/idiokit/__init__.py
@@ -16,6 +16,8 @@ from .timer import sleep
 from .threadpool import thread
 
 
+__version__ = "2.2.0"
+
 __all__ = [
     "stream",
     "next",

--- a/idiokit/http/client.py
+++ b/idiokit/http/client.py
@@ -249,6 +249,10 @@ class Client(object):
     def cert(self):
         return self._cert
 
+    @property
+    def user_agent(self):
+        return ' '.join(self._user_agents)
+
     def mount(self, prefix, adapter):
         """
         Set the adapter for handling URLs that start with the given prefix.
@@ -296,7 +300,7 @@ class Client(object):
             headers["host"] = host
 
         if headers.get("user-agent") is None:
-            headers["user-agent"] = " ".join(self._user_agents)
+            headers["user-agent"] = self.user_agent
 
         connection = get_header_single(headers, "connection", "close")
         if connection.lower() != "close":

--- a/idiokit/http/client.py
+++ b/idiokit/http/client.py
@@ -215,7 +215,8 @@ class HTTPUnixAdapter(_Adapter):
 
 
 class Client(object):
-    def __init__(self, resolver=None, timeout=60.0, verify=True, cert=None):
+    def __init__(self, resolver=None, timeout=60.0, verify=True, cert=None,
+                 user_agent=None):
         _normalize_verify(verify)
         _normalize_cert(cert)
 
@@ -223,6 +224,10 @@ class Client(object):
         self._verify = verify
         self._cert = cert
         self._timeout = timeout
+
+        self._user_agents = ["idiokit/{0}".format(idiokit.__version__)]
+        if user_agent is not None:
+            self._user_agents.insert(0, user_agent)
 
         self._mounts = {}
         self.mount("http://", _HTTPAdapter())
@@ -289,6 +294,9 @@ class Client(object):
         headers = normalized_headers(headers)
         if headers.get("host", None) is None:
             headers["host"] = host
+
+        if headers.get("user-agent") is None:
+            headers["user-agent"] = " ".join(self._user_agents)
 
         connection = get_header_single(headers, "connection", "close")
         if connection.lower() != "close":

--- a/idiokit/http/tests/test_client.py
+++ b/idiokit/http/tests/test_client.py
@@ -47,8 +47,10 @@ def get(client, url):
 class TestClient(unittest.TestCase):
     def test_http_client_user_agent(self):
         client = Client(user_agent="Test Agent")
-        self.assertEqual(client.user_agent,
-                         "Test Agent idiokit/{0}".format(idiokit.__version__))
+        self.assertEqual(
+            client.user_agent,
+            "Test Agent idiokit/{0}".format(idiokit.__version__)
+        )
 
     def test_http_unix_adapter(self):
         @idiokit.stream

--- a/idiokit/http/tests/test_client.py
+++ b/idiokit/http/tests/test_client.py
@@ -45,6 +45,11 @@ def get(client, url):
 
 
 class TestClient(unittest.TestCase):
+    def test_http_client_user_agent(self):
+        client = Client(user_agent="Test Agent")
+        self.assertEqual(client.user_agent,
+                         "Test Agent idiokit/{0}".format(idiokit.__version__))
+
     def test_http_unix_adapter(self):
         @idiokit.stream
         def main(test_string, client):

--- a/idiokit/idiokit.py
+++ b/idiokit/idiokit.py
@@ -10,6 +10,7 @@ from functools import partial, wraps
 from ._selectloop import sleep, asap, iterate
 from .values import Value
 
+__version__ = "2.2.0"
 
 NULL = Value(None)
 

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,8 @@ from distutils.util import convert_path
 from distutils.command.build import build as _build
 from distutils.command.install import install as _install
 
+from idiokit import __version__
+
 
 def rmtree(path):
     try:
@@ -35,10 +37,10 @@ class Install(_install):
 
 setup(
     name="idiokit",
-    version="2.2.0",
+    version=__version__,
     author="Clarified Networks",
     author_email="contact@clarifiednetworks.com",
-    url="https://bitbucket.org/clarifiednetworks/idiokit",
+    url="https://github.com/abusesa/idiokit",
     packages=[
         "idiokit",
         "idiokit.xmpp",


### PR DESCRIPTION
Currently requests made using idiokit HTTP Client have User-Agent header set only if developer manually adds the header. This pull request enables User-Agent header by default.

Default User-Agent is "idiokit/version", i.e. "idiokit/2.2.0".

If developer specifies own user agent when creating Client()-object, it is added to the default User-Agent header.

For example, following code will produce User-Agent header "feedx idiokit/2.2.0".

```python
from idiokit.http.client import Client

client = Client(user_agent="feedx")
```