### PR TITLE
Fix unexpected UnicodeWarnings when creating JID instances

### DIFF
--- a/idiokit/xmpp/jid.py
+++ b/idiokit/xmpp/jid.py
@@ -160,6 +160,10 @@ class JID(object):
     resource = property(lambda x: x._resource)
 
     def __new__(cls, node=None, domain=None, resource=None):
+        node = unicodify(node)
+        domain = unicodify(domain)
+        resource = unicodify(resource)
+
         with cls.cache_lock:
             cache_key = node, domain, resource
             if cache_key in cls.cache:
@@ -170,9 +174,7 @@ class JID(object):
         elif domain is None:
             if resource is not None:
                 raise JIDError("resource not expected with a full JID")
-            node, domain, resource = split_jid(unicodify(node))
-        else:
-            node, domain, resource = map(unicodify, (node, domain, resource))
+            node, domain, resource = split_jid(node)
 
         obj = super(JID, cls).__new__(cls)
         obj._node = prep_node(node)

--- a/idiokit/xmpp/tests/test_jid.py
+++ b/idiokit/xmpp/tests/test_jid.py
@@ -53,7 +53,7 @@ class TestJID(unittest.TestCase):
         with warnings.catch_warnings():
             warnings.simplefilter("error", UnicodeWarning)
             try:
-                self.assertRaises(ValueError, JID, ZeroHashBytes("\xe4@domain.example"))
+                self.assertRaises(UnicodeDecodeError, JID, ZeroHashBytes("\xe4@domain.example"))
             except UnicodeWarning:
                 self.fail("UnicodeWarning raised")
 

--- a/idiokit/xmpp/tests/test_jid.py
+++ b/idiokit/xmpp/tests/test_jid.py
@@ -1,3 +1,5 @@
+import copy
+import pickle
 import unittest
 import warnings
 
@@ -5,16 +7,21 @@ from ..jid import JID, JIDError
 
 
 class TestJID(unittest.TestCase):
-    def test_copy(self):
-        import copy
+    def test_7bit_ascii_byte_strings_should_be_converted_to_unicode(self):
+        self.assertEqual(JID("node@domain/resource"), JID(u"node@domain/resource"))
 
+    def test_non_7bit_ascii_byte_strings_should_cause_UnicodeDecodeErrors(self):
+        self.assertRaises(UnicodeDecodeError, JID, "\xe4@domain/resource")
+
+    def test_instances_should_be_copyable(self):
         jid = JID("a", "b", "c")
         assert copy.copy(jid) == jid
+
+    def test_instances_should_be_deepcopyable(self):
+        jid = JID("a", "b", "c")
         assert copy.deepcopy(jid) == jid
 
-    def test_pickling(self):
-        import pickle
-
+    def test_instances_should_be_picklable_and_unpicklable(self):
         jid = JID("a", "b", "c")
         assert pickle.loads(pickle.dumps(jid)) == jid
 
@@ -50,7 +57,7 @@ class TestJID(unittest.TestCase):
             except UnicodeWarning:
                 self.fail("UnicodeWarning raised")
 
-    def test_unicode(self):
+    def test_instances_should_support_conversion_to_unicode_strings(self):
         jid_string = "node@domain/resource"
         assert unicode(JID(jid_string)) == jid_string
 


### PR DESCRIPTION
Creating a ```idiokit.xmpp.jid.JID``` instances sometimes caused an ```UnicodeWarning``` to be printed. The reason could be tracked back to JID instance caching by repeating the following steps:
 1. Create a JID from an unicode string containing a non-ascii character.
 2. Try to create a JID from a byte string that both
   * contains a character outside of the 7-bit ascii range
   * has the same hash() value as the unicode string from step 1.

The cache dict ended up trying to compare these two incompatible strings, hence the warning. Fixed this by converting input strings to unicode *before* any caching checks.

Many thanks to @anerani for originally spotting the warnings from [abusesa/abusehelper](https://github.com/abusesa/abusehelper) tox test logs.