### PR TITLE
setup.py: Use setuptools instead of distutils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.8.0 (not released)
+
+### Features
+
+ * Switch to setuptools for packaging ([#19](https://github.com/abusesa/idiokit/pull/19))
+
 ## 2.7.1 (2016-05-23)
 
 ### Fixes 

--- a/idiokit/idiokit.py
+++ b/idiokit/idiokit.py
@@ -11,7 +11,7 @@ from functools import wraps
 from ._selectloop import sleep, asap, iterate
 from .values import Value
 
-__version__ = "2.7.1"
+__version__ = "2.8.0"
 
 NULL = Value(None)
 

--- a/setup.py
+++ b/setup.py
@@ -1,39 +1,6 @@
-import os
-import errno
-from distutils.core import setup
-from distutils.dir_util import remove_tree
-from distutils.util import convert_path
-from distutils.command.build import build as _build
-from distutils.command.install import install as _install
+from setuptools import setup, find_packages
 
 from idiokit import __version__
-
-
-def rmtree(path):
-    try:
-        remove_tree(convert_path(path))
-    except OSError, err:
-        if err.errno != errno.ENOENT:
-            raise
-
-
-class Build(_build):
-    def run(self):
-        clean = self.distribution.reinitialize_command("clean", reinit_subcommands=True)
-        clean.all = True
-        self.distribution.run_command("clean")
-        _build.run(self)
-
-
-class Install(_install):
-    def run(self):
-        build_py = self.distribution.get_command_obj("build_py")
-        if self.distribution.packages:
-            for package in self.distribution.packages:
-                package_dir = build_py.get_package_dir(package)
-                rmtree(os.path.join(self.install_lib, package_dir))
-        _install.run(self)
-
 
 setup(
     name="idiokit",
@@ -41,16 +8,6 @@ setup(
     author="Clarified Networks",
     author_email="contact@clarifiednetworks.com",
     url="https://github.com/abusesa/idiokit",
-    packages=[
-        "idiokit",
-        "idiokit.xmpp",
-        "idiokit.dns",
-        "idiokit.http",
-        "idiokit.http.handlers"
-    ],
-    license="MIT",
-    cmdclass={
-        "build": Build,
-        "install": Install
-    }
+    packages=find_packages(exclude=["*.tests"]),
+    license="MIT"
 )


### PR DESCRIPTION
Using setuptools instead of distutils allows getting rid of boilerplate in ```setup.py```, and it seems to be the recommended way for defining Python packages anyway.