### PR TITLE
idiokit.ssl: Add CA bundle info for Alpine Linux, Debian & Fedora

### DIFF
--- a/idiokit/ssl.py
+++ b/idiokit/ssl.py
@@ -91,13 +91,55 @@ def _constant_cert(filename):
     return _cert
 
 
-_distro = platform.linux_distribution(full_distribution_name=False)[0].lower()
-if _distro == "ubuntu":
-    _default_cert = _constant_cert("/etc/ssl/certs/ca-certificates.crt")
-elif _distro == "centos":
-    _default_cert = _constant_cert("/etc/pki/tls/certs/ca-bundle.crt")
-else:
-    _default_cert = _dummy_cert
+def _infer_linux_ca_bundle(ca_bundles_for_distros):
+    """
+    Return a CA certificate bundle typical for the Linux distribution
+    the program is currently running on.
+
+    Inference is based on the argument, assumed to be a dictionary listing
+    potential CA certificate bundle paths and for each path a list of Linux
+    distributions that usually use that path. The distribution names should be
+    given in the format platform.linux_distribution returns when its
+    full_distribution_name argument is set to False. Names are matched
+    case-sensitively.
+
+    >>> distro = platform.linux_distribution(full_distribution_name=False)[0]
+    >>> _infer_linux_ca_bundle({
+    ...     "/path/to/ca-bundle.crt": [distro],
+    ...     "/some/other/ca-bundle.crt": ["other" + distro]
+    ... })
+    '/path/to/ca-bundle.crt'
+
+    Return None when no CA bundle path can be inferred.
+
+    >>> _infer_linux_ca_bundle({})
+    """
+
+    supported_dists = set()
+    for ca_bundle_path, distro_names in ca_bundles_for_distros.items():
+        supported_dists.update(distro_names)
+
+    distro, _, _ = platform.linux_distribution(
+        full_distribution_name=False,
+        supported_dists=supported_dists
+    )
+
+    for ca_bundle_path, distro_names in ca_bundles_for_distros.items():
+        if distro in distro_names:
+            return ca_bundle_path
+    return None
+
+
+_default_cert = _dummy_cert
+
+
+if platform.system().lower() == "linux":
+    _ca_bundle_path = _infer_linux_ca_bundle({
+        "/etc/ssl/certs/ca-certificates.crt": ["ubuntu", "alpine", "debian"],
+        "/etc/pki/tls/certs/ca-bundle.crt": ["centos", "fedora"]
+    })
+    if _ca_bundle_path is not None:
+        _default_cert = _constant_cert(_ca_bundle_path)
 
 
 @idiokit.stream

--- a/idiokit/ssl.py
+++ b/idiokit/ssl.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import os
 import re
 import tempfile
 import platform
@@ -71,17 +70,10 @@ O1m5HRRBQdjLoUrIsOby9i0rQyoEYE44YlUVgLbTKNL2zl+b+Sn/zg5Z+g==
 
 @contextlib.contextmanager
 def _dummy_cert():
-    fd, path = tempfile.mkstemp()
-    try:
-        index = 0
-        while index < len(CERT_DATA):
-            index += os.write(fd, CERT_DATA[index:])
-        os.fsync(fd)
-
-        yield path
-    finally:
-        os.close(fd)
-        os.remove(path)
+    with tempfile.NamedTemporaryFile() as fileobj:
+        fileobj.write(CERT_DATA)
+        fileobj.flush()
+        yield fileobj.name
 
 
 def _constant_cert(filename):

--- a/idiokit/ssl.py
+++ b/idiokit/ssl.py
@@ -152,22 +152,25 @@ def _wrapped(ssl, timeout, func, *args, **keys):
 
 
 @idiokit.stream
-def wrap_socket(sock,
-                keyfile=None,
-                certfile=None,
-                server_side=False,
-                ssl_version=PROTOCOL_SSLv23,
-                require_cert=False,
-                ca_certs=None,
-                timeout=None):
-    keys = dict(
-        keyfile=keyfile,
-        certfile=certfile,
-        server_side=server_side,
-        cert_reqs=_ssl.CERT_REQUIRED if require_cert else _ssl.CERT_NONE,
-        ssl_version=ssl_version,
-        do_handshake_on_connect=False,
-        suppress_ragged_eofs=True)
+def wrap_socket(
+    sock,
+    keyfile=None,
+    certfile=None,
+    server_side=False,
+    ssl_version=PROTOCOL_SSLv23,
+    require_cert=False,
+    ca_certs=None,
+    timeout=None
+):
+    keys = {
+        "keyfile": keyfile,
+        "certfile": certfile,
+        "server_side": server_side,
+        "cert_reqs": _ssl.CERT_REQUIRED if require_cert else _ssl.CERT_NONE,
+        "ssl_version": ssl_version,
+        "do_handshake_on_connect": False,
+        "suppress_ragged_eofs": True
+    }
 
     if not require_cert or ca_certs is not None:
         cert = _constant_cert(ca_certs)


### PR DESCRIPTION
This pull request modifies `idiokit.ssl` to use the following CA bundle paths by default for the following Linux distributions:

 * `/etc/ssl/certs/ca-certificates.crt` for Alpine & Debian (in addition to Ubuntu)
 * `/etc/pki/tls/certs/ca-bundle.crt` for Fedora (in addition to CentOS)

Additionally clean up code in the module.