### PR TITLE
idiokit.ssl: Add redhat to CA bundle paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.7.1 (not released)
+
+### Features
+
+ * Add Red Hat to CA bundle paths in idiokit.ssl ([#24](https://github.com/abusesa/idiokit/pull/24))
+
 
 ## 2.7.0 (2016-05-14)
 

--- a/idiokit/ssl.py
+++ b/idiokit/ssl.py
@@ -110,7 +110,7 @@ def _infer_linux_ca_bundle(ca_bundles_for_distros):
 if platform.system().lower() == "linux":
     _ca_bundle_path = _infer_linux_ca_bundle({
         "/etc/ssl/certs/ca-certificates.crt": ["ubuntu", "alpine", "debian"],
-        "/etc/pki/tls/certs/ca-bundle.crt": ["centos", "fedora"]
+        "/etc/pki/tls/certs/ca-bundle.crt": ["centos", "fedora", "redhat"]
     })
 else:
     _ca_bundle_path = None


### PR DESCRIPTION
RedHat uses the same CA bundle path as CentOS and Fedora.