### PR TITLE
idiokit.xmpp.muc: Add timeout to join_room()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.8.1 (2016-XX-YY)
+
+### Fixes
+
+ * Add timeout to xmpp.muc.join() for case where connection dies while client is waiting for presence messages sent by server ([#29](https://github.com/abusesa/idiokit/pull/29))
+
 ## 2.8.0 (2016-06-22)
 
 ### Features

--- a/idiokit/idiokit.py
+++ b/idiokit/idiokit.py
@@ -11,7 +11,7 @@ from functools import wraps
 from ._selectloop import sleep, asap, iterate
 from .values import Value
 
-__version__ = "2.8.0"
+__version__ = "2.8.1"
 
 NULL = Value(None)
 

--- a/idiokit/xmpp/muc.py
+++ b/idiokit/xmpp/muc.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import random
 
-from .. import idiokit
+from .. import idiokit, timer
 from ..xmlcore import Element
 from .core import STANZA_NS, XMPPError
 from .jid import JID
@@ -65,7 +65,10 @@ def join_room(jid, xmpp, output, password=None, history=False):
     yield xmpp.core.presence(x, to=JID(jid))
 
     while True:
-        element = yield output.next()
+        try:
+            element = yield timer.timeout(120.0, output.next())
+        except timer.Timeout:
+            raise MUCError("timeout while joining room {0!r}".format(unicode(jid.bare())))
 
         parsed = parse_presence(element, jid)
         if parsed is None:


### PR DESCRIPTION
There have been multiple reports that bots still hang every now and then during startup process. We have already added some timeouts and fixed some problems, but it seems that there was at least one place that missed timeout; loop that handles presence messages sent by server when client is joining to chat room.

This pull-request will add 120s timeout for these cases. After that MUCError() is raised, which can be then handled by bot or any other code using idiokit.