### PR TITLE
Fix test cases

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,13 +6,17 @@ skip_missing_interpreters = true
 deps = pytest
 commands = py.test {posargs}
 
+[testenv:py26]
+deps = unittest2
+commands = unit2 discover
+
 [testenv:flake8]
 deps = flake8
 commands = flake8
 skip_install = true
 
 [flake8]
-ignore = E501
+ignore = E501,E722
 exclude = build,dist,.git,.tox
 
 [pytest]


### PR DESCRIPTION
Problems are caused by pytest dropping support for py26 and flake8 updating to version 3.5.0, which has an added check for E722.